### PR TITLE
add stage environment

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,9 +1,2 @@
 NODE_ENV=production
-VUE_APP_BACKEND_URL=https://m8k4nu7u9b.execute-api.eu-west-1.amazonaws.com/dev
-VUE_APP_REGION=eu-west-1
-VUE_APP_POOL_ID=eu-west-1_PjheiOKMY
-VUE_APP_CLIENT_ID=1ijrh5rpge4dej019mqivrh855
-VUE_APP_IDENTITY_POOL_ID=eu-west-1:e47dc275-cad1-4ebd-a698-a2934e5c725b
-VUE_APP_GOOGLE_MAPS_API_KEY=AIzaSyDAn_0kVpzkaMDGJsHiW_dARSF8GDelipU
-VUE_APP_STRIPE_PUBLIC_KEY=pk_test_NnSWFlcmJKJBBXdWvKd4QyUR004XeI4jAz
 

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,9 @@
+NODE_ENV=production
+VUE_APP_BACKEND_URL=https://m8k4nu7u9b.execute-api.eu-west-1.amazonaws.com/dev
+VUE_APP_REGION=eu-west-1
+VUE_APP_POOL_ID=eu-west-1_PjheiOKMY
+VUE_APP_CLIENT_ID=1ijrh5rpge4dej019mqivrh855
+VUE_APP_IDENTITY_POOL_ID=eu-west-1:e47dc275-cad1-4ebd-a698-a2934e5c725b
+VUE_APP_GOOGLE_MAPS_API_KEY=AIzaSyDAn_0kVpzkaMDGJsHiW_dARSF8GDelipU
+VUE_APP_STRIPE_PUBLIC_KEY=pk_test_NnSWFlcmJKJBBXdWvKd4QyUR004XeI4jAz
+

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build:prod": "vue-cli-service build --mode production",
-    "build:dev": "vue-cli-service build --mode development",
+    "build:stage": "vue-cli-service build --mode staging",
     "lint": "run-s lint:all:*",
     "deploy:prod": "vue-cli-service s3-deploy --mode production",
-    "deploy:dev": "vue-cli-service s3-deploy --mode development",
+    "deploy:stage": "vue-cli-service s3-deploy --mode staging",
     "lint:all:eslint": "yarn lint:eslint --ext .js,.vue .",
     "lint:all:markdownlint": "yarn lint:markdownlint \"docs/*.md\" \"*.md\"",
     "lint:all:prettier": "yarn lint:prettier \"**/*.{js,json,css,scss,vue,html,md}\"",


### PR DESCRIPTION
I had to change how we build and deploy for DEV. In VueJS when you build for dev, it means you will only use it locally and not deploy it on a server. And the whole application is not even compiled.

Even staging will not compile the code for production. That's why I had to specify the `NODE_ENV` to be `production`.